### PR TITLE
Fix `next()` Method of the Stream Does Not Return Nil When the Pipe is Closed

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "xlibb"
 name = "pipe"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["xlibb"]
 keywords = ["pipe"]
 repository = "https://github.com/xlibb/module-pipe"
@@ -10,4 +10,4 @@ distribution = "2201.2.0"
 icon = "icon.png"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/pipe-native-1.1.0.jar"
+path = "../native/build/libs/pipe-native-1.1.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -53,7 +53,7 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "pipe"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/stream_generator.bal
+++ b/ballerina/stream_generator.bal
@@ -25,7 +25,7 @@ class StreamGenerator {
 
     public isolated function next() returns record {|any value;|}|Error? {
         any streamValue = check self.resultIterator.nextValue(self);
-        return {value: streamValue};
+        return streamValue is () ? () : {value: streamValue};
     }
 
     public isolated function close() returns Error? {

--- a/ballerina/tests/pipe_test.bal
+++ b/ballerina/tests/pipe_test.bal
@@ -40,7 +40,7 @@ function testPipeWithRecords() returns error? {
     record {|MovieRecord value;|}? 'record = check 'stream.next();
     MovieRecord actualValue = (<record {|MovieRecord value;|}>'record).value;
     MovieRecord expectedValue = movieRecord;
-    test:assertEquals(expectedValue, actualValue);
+    test:assertEquals(actualValue, expectedValue);
 }
 
 @test:Config {
@@ -55,7 +55,7 @@ function testPipeStream() returns error? {
         string expectedValue = i.toString();
         record {|string value;|}? data = check 'stream.next();
         string actualValue = (<record {|string value;|}>data).value;
-        test:assertEquals(expectedValue, actualValue);
+        test:assertEquals(actualValue, expectedValue);
     }
     check 'stream.close();
     string expectedValue = "Events cannot be produced to a closed pipe.";
@@ -80,7 +80,7 @@ function testImmediateClose() returns error? {
 }
 
 @test:Config {
-    groups: ["close", "main_apis", "test"]
+    groups: ["close", "main_apis"]
 }
 function testConsumeStreamAfterClose() returns error? {
     Pipe pipe = new(5);
@@ -90,8 +90,7 @@ function testConsumeStreamAfterClose() returns error? {
     stream<int, error?> result = pipe.consumeStream(5);
     check pipe.immediateClose();
     var actualValue = check result.next();
-    var expectedValue = { value: ()};
-    test:assertEquals(actualValue, expectedValue);
+    test:assertEquals(actualValue, ());
 }
 
 @test:Config {

--- a/changelog.md
+++ b/changelog.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+- [[#8] Fix `next()` Method of the Stream Does Not Return Nil When the Pipe is Closed](https://github.com/xlibb/module-pipe/issues/8)
+
 ## [1.1.0] - 2022-10-26
 
 ### Changed
-- [[#4](The Stream Returning from the `consumeStream` API Returns Nil When the Pipe is Closed)](https://github.com/xlibb/module-pipe/issues/4)
+- [[#4] The Stream Returning from the `consumeStream` API Returns Nil When the Pipe is Closed](https://github.com/xlibb/module-pipe/issues/4)
 - Moved to the xlibb organization in Ballerina central. Version 1 was released in the `nuvindu` organization in Ballerina central.


### PR DESCRIPTION
## Purpose

$Subject

Fixes: #8 

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
