### PR TITLE
Update the APIs to Validate Timeouts and Handle Non Bound Waiting

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "xlibb"
 name = "pipe"
-version = "1.1.3"
+version = "1.2.0"
 authors = ["xlibb"]
 keywords = ["pipe"]
 repository = "https://github.com/xlibb/module-pipe"
@@ -10,4 +10,4 @@ distribution = "2201.2.0"
 icon = "icon.png"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/pipe-native-1.1.3-SNAPSHOT.jar"
+path = "../native/build/libs/pipe-native-1.2.0-SNAPSHOT.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "xlibb"
 name = "pipe"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["xlibb"]
 keywords = ["pipe"]
 repository = "https://github.com/xlibb/module-pipe"
@@ -10,4 +10,4 @@ distribution = "2201.2.0"
 icon = "icon.png"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/pipe-native-1.1.2.jar"
+path = "../native/build/libs/pipe-native-1.1.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -53,7 +53,7 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "pipe"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -53,7 +53,7 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "pipe"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -1,6 +1,6 @@
-## Overview
+## Package Overview
 
-This module provides a medium to send and receive events simultaneously. And it includes APIs to produce, consume and return events via a stream.
+This package provides a medium to send and receive events simultaneously. And it includes APIs to produce, consume and return events via a stream.
 
 ## Pipe
 
@@ -20,12 +20,12 @@ public function main() returns error? {
 
 ### APIs associated with Pipe
 
-- <b> produce </b>: Produces events into the pipe. If the pipe is full, it blocks further producing events.
-- <b> consume </b>: Consumes events in the pipe. If the pipe is empty, it blocks until events are available in the pipe.
-- <b> consumeStream </b>: Returns a stream. Events can be consumed by iterating the stream.
-- <b> immediateClose </b>: Closes the pipe instantly. All the events in the pipe will be discarded.
-- <b> gracefulClose </b>: Closes the pipe gracefully. A grace period is provided to consume available events in the pipe. After the period, all the events will be discarded.
-- <b> isClosed </b>: Returns the closing status of the pipe.
+- **produce**: Produces events into the pipe. If the pipe is full, it blocks further producing events.
+- **consume**: Consumes events in the pipe. If the pipe is empty, it blocks until events are available in the pipe.
+- **consumeStream**: Returns a stream. Events can be consumed by iterating the stream.
+- **immediateClose**: Closes the pipe instantly. All the events in the pipe will be discarded.
+- **gracefulClose**: Closes the pipe gracefully. A grace period is provided to consume available events in the pipe. After the period, all the events will be discarded.
+- **isClosed**: Returns the closing status of the pipe.
 
 #### Produce Events
 
@@ -68,8 +68,7 @@ public function main() returns error? {
 
 Using the following method, events in the pipe can be consumed via a stream. The stream type is inferred using the expected type from the function. If the return type cannot be cast into the expected type it will return a `TypeCast Error`.
 
-The `consume` method is used here as an underlying method. Therefore a `timeout` needs to be set to
-specify the maximum waiting period to consume events.
+The `consume` method is used here as an underlying method. Therefore a `timeout` needs to be set to specify the maximum waiting period to consume events.
 
 ```ballerina
 import ballerina/io;
@@ -80,7 +79,7 @@ public function main() returns error? {
     string event = "event";
     check pipe.produce(event, timeout = 5);
 
-    stream<string, error?> eventStream = pipe.consumeStream(timeout = 5.12323);
+    stream<string, error?> eventStream = check pipe.consumeStream(timeout = 5.12323);
     record {|string value;|}? nextEvent = check eventStream.next();
     if nextEvent != () {
         string consumedEvent = nextEvent.value;

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -1,6 +1,6 @@
-## Package Overview
+## Overview
 
-This package provides a medium to send and receive events simultaneously. And it includes APIs to produce, consume and return events via a stream.
+This module provides a medium to send and receive events simultaneously. And it includes APIs to produce, consume and return events via a stream.
 
 ## Pipe
 

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -20,12 +20,12 @@ public function main() returns error? {
 
 ### APIs associated with Pipe
 
-- <b> produce </b>: Produces events into the pipe. If the pipe is full, it blocks further producing events.
-- <b> consume </b>: Consumes events in the pipe. If the pipe is empty, it blocks until events are available in the pipe.
-- <b> consumeStream </b>: Returns a stream. Events can be consumed by iterating the stream.
-- <b> immediateClose </b>: Closes the pipe instantly. All the events in the pipe will be discarded.
-- <b> gracefulClose </b>: Closes the pipe gracefully. A grace period is provided to consume available events in the pipe. After the period, all the events will be discarded.
-- <b> isClosed </b>: Returns the closing status of the pipe.
+- **produce**: Produces events into the pipe. If the pipe is full, it blocks further producing events.
+- **consume**: Consumes events in the pipe. If the pipe is empty, it blocks until events are available in the pipe.
+- **consumeStream**: Returns a stream. Events can be consumed by iterating the stream.
+- **immediateClose**: Closes the pipe instantly. All the events in the pipe will be discarded.
+- **gracefulClose**: Closes the pipe gracefully. A grace period is provided to consume available events in the pipe. After the period, all the events will be discarded.
+- **isClosed**: Returns the closing status of the pipe.
 
 #### Produce Events
 
@@ -68,8 +68,7 @@ public function main() returns error? {
 
 Using the following method, events in the pipe can be consumed via a stream. The stream type is inferred using the expected type from the function. If the return type cannot be cast into the expected type it will return a `TypeCast Error`.
 
-The `consume` method is used here as an underlying method. Therefore a `timeout` needs to be set to
-specify the maximum waiting period to consume events.
+The `consume` method is used here as an underlying method. Therefore a `timeout` needs to be set to specify the maximum waiting period to consume events.
 
 ```ballerina
 import ballerina/io;
@@ -80,7 +79,7 @@ public function main() returns error? {
     string event = "event";
     check pipe.produce(event, timeout = 5);
 
-    stream<string, error?> eventStream = pipe.consumeStream(timeout = 5.12323);
+    stream<string, error?> eventStream = check pipe.consumeStream(timeout = 5.12323);
     record {|string value;|}? nextEvent = check eventStream.next();
     if nextEvent != () {
         string consumedEvent = nextEvent.value;

--- a/ballerina/pipe.bal
+++ b/ballerina/pipe.bal
@@ -35,7 +35,8 @@ public isolated class Pipe {
     # Produces an event into the pipe.
     #
     # + event - The event that needs to be produced to the pipe. Can be `any` type
-    # + timeout - The maximum waiting period that holds the event
+    # + timeout - The maximum waiting period that holds the event. Set the timeout to `-1` to wait without a time limit.
+    #             Any other negative value will return a `pipe:Error`
     # + return - Returns `()` if the event is successfully produced. Otherwise returns a `pipe:Error`
     public isolated function produce(any event, decimal timeout) returns Error? = @java:Method {
         'class: "io.xlibb.pipe.Pipe"
@@ -43,7 +44,8 @@ public isolated class Pipe {
 
     # Consumes an event in the pipe.
     #
-    # + timeout - The maximum waiting period to consume the event
+    # + timeout - The maximum waiting period to consume the event. Set the timeout to `-1` to wait without a time limit.
+    #             Any other negative value will return a `pipe:Error`
     # + typeParam - The `type` of data that is needed to be consumed. When not provided, the type is inferred
     # using the expected type from the function
     # + return - Return type is inferred from the user specified type. That should be the same event type
@@ -55,12 +57,13 @@ public isolated class Pipe {
 
     # Consumes events in the pipe as a `stream`
     #
-    # + timeout - The maximum waiting period to consume events
+    # + timeout - The maximum waiting period to consume events. Set the timeout to `-1` to wait without a time limit.
+    #             Any other negative value will return a `pipe:Error`
     # + typeParam - The `type` of data that is needed to be consumed. When not provided, the type is inferred
     # using the expected type from the function
     # + return - Returns a `stream`. The stream type is inferred from the user specified type
     public isolated function consumeStream(decimal timeout, typedesc<any> typeParam = <>)
-        returns stream<typeParam, error?> = @java:Method {
+        returns stream<typeParam, error?>|Error = @java:Method {
         'class: "io.xlibb.pipe.Pipe"
     } external;
 
@@ -74,7 +77,8 @@ public isolated class Pipe {
 
     # Closes the pipe gracefully. Waits for some grace period until all the events in the pipe is consumed.
     #
-    # + timeout - The maximum grace period to wait until the pipe is empty
+    # + timeout - The maximum grace period to wait until the pipe is empty. Setting the timeout to a negative value will
+    #             return a `pipe:Error`
     # + return - Return `()`, if the pipe is successfully closed. Otherwise returns a `pipe:Error`
     public isolated function gracefulClose(decimal timeout = 30) returns Error? = @java:Method {
         'class: "io.xlibb.pipe.Pipe"

--- a/ballerina/tests/errors_test.bal
+++ b/ballerina/tests/errors_test.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/test;
+import ballerina/lang.runtime;
 import ballerina/time;
 
 @test:Config {
@@ -170,6 +171,32 @@ isolated function testNegativeTimeout() returns error? {
         validateTimeoutErrorCause(closeResult, expectedMessage, expectedCause);
     } else {
         test:assertFail("Expected an error");
+    }
+}
+
+@test:Config {
+    groups: ["main_apis"]
+}
+function testInfiniteWaiting() returns error? {
+    Pipe pipe = new (1);
+
+    worker A {
+        foreach int i in 0..<3 {
+            var result = pipe.produce(i, -1);
+            if result is Error {
+                test:assertFail("Unexpected error occurred");
+            }
+        }
+    }
+
+    worker B {
+        foreach int i in 0..<3 {
+            int|error result = pipe.consume(-1);
+            if result is error {
+                test:assertFail("Unexpected error occurred");
+            }
+            runtime:sleep(31);
+        }
     }
 }
 

--- a/ballerina/tests/errors_test.bal
+++ b/ballerina/tests/errors_test.bal
@@ -172,6 +172,13 @@ isolated function testNegativeTimeout() returns error? {
     } else {
         test:assertFail("Expected an error");
     }
+    closeResult = pipe.gracefulClose(-1);
+    if closeResult is Error {
+        string expectedMessage = "Graceful close must provide 0 or greater timeout";
+        test:assertEquals(closeResult.message(), expectedMessage);
+    } else {
+        test:assertFail("Expected an error");
+    }
 }
 
 @test:Config {
@@ -195,7 +202,7 @@ function testInfiniteWaiting() returns error? {
             if result is error {
                 test:assertFail("Unexpected error occurred");
             }
-            runtime:sleep(31);
+            runtime:sleep(5);
         }
     }
 }

--- a/ballerina/tests/pipe_test.bal
+++ b/ballerina/tests/pipe_test.bal
@@ -36,7 +36,7 @@ function testPipeWithRecords() returns error? {
     Pipe pipe = new(5);
     MovieRecord movieRecord = {name: "The Trial of the Chicago 7", director: "Aaron Sorkin"};
     check pipe.produce(movieRecord, timeout = 5);
-    stream<MovieRecord, error?> 'stream = pipe.consumeStream(5);
+    stream<MovieRecord, error?> 'stream = check pipe.consumeStream(5);
     record {|MovieRecord value;|}? 'record = check 'stream.next();
     MovieRecord actualValue = (<record {|MovieRecord value;|}>'record).value;
     MovieRecord expectedValue = movieRecord;
@@ -50,7 +50,7 @@ function testPipeStream() returns error? {
     Pipe pipe = new(5);
     check pipe.produce("1", timeout = 5);
     check pipe.produce("2", timeout = 5);
-    stream<string, error?> 'stream = pipe.consumeStream(timeout = 5);
+    stream<string, error?> 'stream = check pipe.consumeStream(timeout = 5);
     foreach int i in 1 ..< 3 {
         string expectedValue = i.toString();
         record {|string value;|}? data = check 'stream.next();
@@ -58,7 +58,7 @@ function testPipeStream() returns error? {
         test:assertEquals(actualValue, expectedValue);
     }
     check 'stream.close();
-    string expectedValue = "Events cannot be produced to a closed pipe.";
+    string expectedValue = "Events cannot be produced to a closed pipe";
     Error? actualValue = pipe.produce("1", timeout = 5);
     test:assertTrue(actualValue is Error);
     test:assertEquals((<Error>actualValue).message(), expectedValue);
@@ -87,7 +87,7 @@ function testConsumeStreamAfterClose() returns error? {
     foreach int i in 0..<5 {
         check pipe.produce(i, 5);
     }
-    stream<int, error?> result = pipe.consumeStream(5);
+    stream<int, error?> result = check pipe.consumeStream(5);
     check pipe.immediateClose();
     var actualValue = check result.next();
     test:assertEquals(actualValue, ());
@@ -100,7 +100,7 @@ function testGracefulClose() returns error? {
     Pipe pipe = new(5);
     check pipe.produce("1", timeout = 5);
     check pipe.gracefulClose(timeout = 5);
-    string expectedValue = "Events cannot be produced to a closed pipe.";
+    string expectedValue = "Events cannot be produced to a closed pipe";
     Error? actualValue = pipe.produce("1", timeout = 5);
     test:assertTrue(actualValue is Error);
     test:assertEquals((<Error>actualValue).message(), expectedValue);
@@ -140,7 +140,7 @@ function testWaitingInGracefulClose() returns error? {
         test:assertTrue(actualValue !is Error);
         test:assertEquals(actualValue, expectedValue);
 
-        string expectedErrorMessage = "Operation has timed out.";
+        string expectedErrorMessage = "Operation has timed out";
         test:assertTrue(actualError is Error);
         string actualErrorMessage = (<error>actualError).message();
         test:assertEquals(actualErrorMessage, expectedErrorMessage);

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## Changed
+- [[#14] Validate Timeout Values and Allow `-1` as a Timeout Value for Unbounded API Calls](https://github.com/xlibb/module-pipe/issues/14)
+
 ## [1.1.2] - 2022-10-27
 
 ## Fixed

--- a/examples/covid_report/main.bal
+++ b/examples/covid_report/main.bal
@@ -37,7 +37,10 @@ public function main() returns error? {
     }
 
     worker B {
-        stream<Report, error?> covidReports = pipe.consumeStream(timeout = 5.12323);
+        stream<Report, error?>|pipe:Error covidReports = pipe.consumeStream(timeout = 5.12323);
+        if covidReports is pipe:Error {
+            return;
+        }
         CovidRecord|error? covidRecord = covidReports.next();
         int i = 0;
         while covidRecord is CovidRecord {

--- a/examples/covid_report/tests/report_test.bal
+++ b/examples/covid_report/tests/report_test.bal
@@ -31,7 +31,10 @@ function testPipeConcurrently() returns error? {
     }
 
     worker B {
-        stream<int, error?> intStream = pipe.consumeStream(timeout = 10.12323);
+        stream<int, error?>|pipe:Error intStream = pipe.consumeStream(timeout = 10.12323);
+        if intStream is pipe:Error {
+            return;
+        }
         IntRecord|error? 'record = intStream.next();
         int i = 0;
         while 'record is IntRecord {
@@ -61,7 +64,10 @@ function testPipeWithObjectsConcurrently() returns error? {
     }
 
     worker B {
-        stream<Report, error?> covidReports = pipe.consumeStream(timeout = 10.12323);
+        stream<Report, error?>|pipe:Error covidReports = pipe.consumeStream(timeout = 10.12323);
+        if covidReports is pipe:Error {
+            return;
+        }
         CovidRecord|error? covidRecord = covidReports.next();
         test:assertExactEquals(covidRecord, report);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.xlibb
-version=1.1.3-SNAPSHOT
+version=1.2.0-SNAPSHOT
 ballerinaLangVersion=2201.2.0
 
 checkstylePluginVersion=8.18

--- a/native/src/main/java/io/xlibb/pipe/Pipe.java
+++ b/native/src/main/java/io/xlibb/pipe/Pipe.java
@@ -130,10 +130,9 @@ public class Pipe implements IPipe {
     protected void asyncClose(Callback callback, long timeout) {
         if (this.isClosed.get()) {
             callback.onError(createError("Closing of a closed pipe is not allowed"));
+        } else if (timeout == -1) {
+            callback.onError(createError("Graceful close must provide 0 or greater timeout"));
         } else {
-            if (timeout == -1) {
-                callback.onError(createError("Graceful close must provide 0 or greater timeout"));
-            }
             this.isClosed.compareAndSet(false, true);
             if (this.queueSize.get() != 0) {
                 emptyQueue.registerObserver(callback);

--- a/native/src/main/java/io/xlibb/pipe/ResultIterator.java
+++ b/native/src/main/java/io/xlibb/pipe/ResultIterator.java
@@ -18,7 +18,6 @@ package io.xlibb.pipe;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.Future;
-import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BObject;
 import io.xlibb.pipe.observer.Callback;
@@ -37,7 +36,7 @@ public class ResultIterator {
         if (pipe != null) {
             Future future = env.markAsync();
             Callback observer = new Callback(future, pipe.getProducer(), pipe.getTimeKeeper(), pipe.getConsumer());
-            BDecimal timeout = (BDecimal) streamGenerator.getNativeData(TIME_OUT);
+            long timeout = (long) streamGenerator.getNativeData(TIME_OUT);
             pipe.asyncConsume(observer, timeout);
             return null;
         }
@@ -45,11 +44,11 @@ public class ResultIterator {
     }
 
     public static BError close(Environment env, BObject streamGenerator) {
-        BDecimal timeOut = (BDecimal) streamGenerator.getNativeData(TIME_OUT);
+        long timeOut = (long) streamGenerator.getNativeData(TIME_OUT);
         Pipe pipe = ((Pipe) streamGenerator.getNativeData(NATIVE_PIPE));
         if (pipe == null) {
-            BError cause = createError("Closing of a closed pipe is not allowed.");
-            return createError("Failed to close the stream.", cause);
+            BError cause = createError("Closing of a closed pipe is not allowed");
+            return createError("Failed to close the stream", cause);
         }
         Future future = env.markAsync();
         Callback observer = new Callback(future, null, null, null);

--- a/native/src/main/java/io/xlibb/pipe/observer/Notifier.java
+++ b/native/src/main/java/io/xlibb/pipe/observer/Notifier.java
@@ -21,6 +21,6 @@ public class Notifier extends TimerTask {
      */
     @Override
     public void run() {
-        this.timeKeeper.notifyObservers(Utils.createError("Operation has timed out."), this.callback);
+        this.timeKeeper.notifyObservers(Utils.createError("Operation has timed out"), this.callback);
     }
 }


### PR DESCRIPTION
## Purpose
$Subject

Fixes: #14 

## Examples

Timeout values cannot be negative (Other than `-1`).
```ballerina
pipe:Pipe pipe = new pipe(5);
check pipe.produce("Hello", -10); // This will return an error
```

The timeout value can be `-1`. In this case, the API call will not be timed out.

```ballerina
pipe:Pipe pipe = new(5);
check pipe.produce("Hello", -1); // This will wait until the pipe is free to produce and will not return an error on time out.
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
