### PR TITLE
Only Allow Async-Ready Events

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "xlibb"
 name = "pipe"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["xlibb"]
 keywords = ["pipe"]
 repository = "https://github.com/xlibb/module-pipe"
@@ -10,4 +10,4 @@ distribution = "2201.2.0"
 icon = "icon.png"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/pipe-native-1.2.0.jar"
+path = "../native/build/libs/pipe-native-1.3.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -53,7 +53,7 @@ modules = [
 [[package]]
 org = "xlibb"
 name = "pipe"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/pipe.bal
+++ b/ballerina/pipe.bal
@@ -34,11 +34,11 @@ public isolated class Pipe {
 
     # Produces an event into the pipe.
     #
-    # + event - The event that needs to be produced to the pipe. Can be `any` type
+    # + event - The event that needs to be produced to the pipe. This only supports `readonly|isolated object {}` types
     # + timeout - The maximum waiting period that holds the event. Set the timeout to `-1` to wait without a time limit.
     #             Any other negative value will return a `pipe:Error`
     # + return - Returns `()` if the event is successfully produced. Otherwise returns a `pipe:Error`
-    public isolated function produce(any event, decimal timeout) returns Error? = @java:Method {
+    public isolated function produce(Event event, decimal timeout) returns Error? = @java:Method {
         'class: "io.xlibb.pipe.Pipe"
     } external;
 

--- a/ballerina/tests/pipe_test.bal
+++ b/ballerina/tests/pipe_test.bal
@@ -35,7 +35,7 @@ function testPipe() returns error? {
 function testPipeWithRecords() returns error? {
     Pipe pipe = new(5);
     MovieRecord movieRecord = {name: "The Trial of the Chicago 7", director: "Aaron Sorkin"};
-    check pipe.produce(movieRecord, timeout = 5);
+    check pipe.produce(movieRecord.cloneReadOnly(), timeout = 5);
     stream<MovieRecord, error?> 'stream = check pipe.consumeStream(5);
     record {|MovieRecord value;|}? 'record = check 'stream.next();
     MovieRecord actualValue = (<record {|MovieRecord value;|}>'record).value;

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Represents the type of the events that can be published to pubsub.
+# The events must be either a `readonly` value, or an `isolated object {}` type.
+public type Event readonly|isolated object {};

--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [[#17] Only Allow `readonly|isolated object {}` types as the events](https://github.com/xlibb/module-pipe/issues/17)
+
 ## [1.2.0] - 2022-10-28
 
-## Changed
+### Changed
 - [[#14] Validate Timeout Values and Allow `-1` as a Timeout Value for Unbounded API Calls](https://github.com/xlibb/module-pipe/issues/14)
 
 ## [1.1.2] - 2022-10-27

--- a/examples/covid_report/main.bal
+++ b/examples/covid_report/main.bal
@@ -24,7 +24,7 @@ public function main() returns error? {
     Report[] reports = check getReportData();
     worker A {
         foreach Report report in reports {
-            pipe:Error? produce = pipe.produce(report, timeout = 5);
+            pipe:Error? produce = pipe.produce(report.cloneReadOnly(), timeout = 5);
             if produce is pipe:Error {
                 log:printError("Error occurred while producing data to the pipe", produce);
             }

--- a/examples/covid_report/tests/report_test.bal
+++ b/examples/covid_report/tests/report_test.bal
@@ -59,7 +59,7 @@ function testPipeWithObjectsConcurrently() returns error? {
         deaths: 16511
     };
     worker A {
-        pipe:Error? produce = pipe.produce(report, timeout = 5.00111);
+        pipe:Error? produce = pipe.produce(report.cloneReadOnly(), timeout = 5.00111);
         test:assertTrue(produce !is pipe:Error);
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.xlibb
-version=1.2.1-SNAPSHOT
+version=1.3.0-SNAPSHOT
 ballerinaLangVersion=2201.2.0
 
 checkstylePluginVersion=8.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,9 +11,13 @@ releasePluginVersion=2.6.0
 ballerinaGradlePluginVersion=0.14.1
 
 #stdlib dependencies
+
+# Level 01
 stdlibIoVersion=1.3.0
-stdlibLogVersion=2.4.1
 stdlibTimeVersion=2.2.2
+
+# Level 02
+stdlibLogVersion=2.4.1
 
 # Ballerinax Observer
 observeVersion=1.0.5


### PR DESCRIPTION
## Purpose

With this change, the pipe object will only allow `readonly|isolated object {}` types as the events. This is to support to make the PubSub object isolated.

Fixes: #17 

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
