### PR TITLE
Revert "Update GraalVM Check workflow to use xlibb-commons template"

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm.yml
+++ b/.github/workflows/build-with-bal-test-graalvm.yml
@@ -30,7 +30,7 @@ jobs:
     call_stdlib_workflow:
         name: Run StdLib Workflow
         if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-        uses: xlibb/xlibb-commons/.github/workflows/build-with-bal-test-graalvm-template.yml@main
+        uses: ballerina-platform/ballerina-standard-library/.github/workflows/build-with-bal-test-graalvm-template.yml@main
         with:
             lang_tag: ${{ inputs.lang_tag }}
             lang_version: ${{ inputs.lang_version }}


### PR DESCRIPTION
This reverts commit d3bc1f776e513eaf88587eca6c51a1caa93535d3.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
