### PR TITLE
Update trivy-scan template to fix the workflow error

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -29,11 +29,12 @@ jobs:
             -   name: Run Trivy vulnerability scanner
                 uses: aquasecurity/trivy-action@master
                 with:
-                    scan-type: 'rootfs'
-                    scan-ref: '/github/workspace/ballerina/lib'
-                    format: 'table'
-                    timeout: '10m0s'
-                    exit-code: '1'
+                    scan-type: "rootfs"
+                    scan-ref: "${{ github.workspace }}/ballerina/lib"
+                    format: "table"
+                    timeout: "10m0s"
+                    exit-code: "1"
+                    scanners: "vuln"
 
             -   name: Publish artifact
                 env:


### PR DESCRIPTION
## Purpose
The trivy scan fails when running the workflow to publish the package to central

https://github.com/xlibb/module-pipe/actions/runs/11721359216/job/32648609214#step:7:234

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
