### PR TITLE
Fix the trivy-scan template in publish release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,11 +38,12 @@ jobs:
             -   name: Run Trivy vulnerability scanner
                 uses: aquasecurity/trivy-action@master
                 with:
-                    scan-type: 'rootfs'
-                    scan-ref: '/github/workspace/ballerina/lib'
-                    format: 'table'
-                    timeout: '10m0s'
-                    exit-code: '1'
+                    scan-type: "rootfs"
+                    scan-ref: "${{ github.workspace }}/ballerina/lib"
+                    format: "table"
+                    timeout: "10m0s"
+                    exit-code: "1"
+                    scanners: "vuln"
 
             -   name: Get Release Version
                 run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV


### PR DESCRIPTION
## Purpose

The trivy scan fails when running the workflow to publish the package to central

https://github.com/xlibb/module-pipe/actions/runs/11721359216/job/32648609214#step:7:234