### PR TITLE
Ignore uncommitted build files while publishing the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ hs_err_pid*
 target
 build
 bin
+.cache/
 
 # Ballerina
 velocity.log*


### PR DESCRIPTION
## Purpose
This is to remove the uncommitted files created when building the package.
https://github.com/xlibb/module-pipe/actions/runs/11739887570/job/32705305797#step:10:34
